### PR TITLE
'make dev-index' was failing because 'binaries' was unknown to make; is this an OK fix?

### DIFF
--- a/engines/tantivy-0.19/Makefile
+++ b/engines/tantivy-0.19/Makefile
@@ -8,7 +8,7 @@ clean:
 clean-index:
 	@rm -fr idx
 
-index: binaries
+index: target/release/build_index
 	@echo "--- Indexing $(NAME) with $(INDEX_DELETE_PCT)% deletes ---"
 	@mkdir -p idx
 	@target/release/build_index idx $(INDEX_DELETE_PCT) < $(CORPUS)


### PR DESCRIPTION
I was getting this error trying to `make dev-index` on a clean clone:

```
[mike@raptorlake search-benchmark-game]$ make dev-index
--- Indexing dev corpus ---
/s0/l/search-benchmark-game/corpus/20k-enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt
make[1]: Entering directory '/s0/l/search-benchmark-game/engines/tantivy-0.19'
make[1]: *** No rule to make target 'binaries', needed by 'index'.  Stop.
make[1]: Leaving directory '/s0/l/search-benchmark-game/engines/tantivy-0.19'
make[1]: Entering directory '/s0/l/search-benchmark-game/engines/lucene-9.5.0'
make[1]: Nothing to be done for 'index'.
make[1]: Leaving directory '/s0/l/search-benchmark-game/engines/lucene-9.5.0'
```

Makefile is not my strong suit!!