### PR TITLE
Makefile add serve_local, also some readme changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,14 +64,19 @@ bench_many: compile
 	@python3 src/run_many.py $(QUERY_FILE) $(MANY_ITERS) $(ENGINES)
 
 overlap_100:
-	@echo "--- Running Overalp Test (compare top 100) ---"
+	@echo "--- Running Overlap Test (compare top 100) ---"
 	@python3 src/overlap.py "queries/basic_queries_no_sloppy_phrase.jsonl" $(ENGINES)
 
 compile:
 	@echo "--- Compiling binaries ---"
 	@for engine in $(ENGINES); do cd ${shell pwd}/engines/$$engine && make compile ; done
 
+serve_local:
+	@echo "--- Serving results locally ---"
+	@cp results.json web/build/results.json
+	@cd web/build && python3 -m http.server $(PORT) --bind localhost
+
 serve:
 	@echo "--- Serving results ---"
 	@cp results.json web/build/results.json
-	@cd web/build && python3 -m http.server $(PORT) --bind localhost
+	@cd web/build && python3 -m http.server $(PORT)

--- a/README.md
+++ b/README.md
@@ -6,14 +6,21 @@ It aims to achieve a close comparison between Tantivy and Lucene using the same 
 
 The latest results can be found [here](https://tony-x.github.io/search-benchmark-game/).
 
-Want to run the benchmark or make changes? here is the [development guide](#development-guide) 
+Want to run the benchmark or make changes? Here is the [development guide](#development-guide).
 
 # The benchmark
 ## Workload
 The corpus used in the benchmark is a snapshot of the English Wikipedia text.
 
 ```
-# wget http://home.apache.org/~mikemccand/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma
+wget http://home.apache.org/~mikemccand/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma
+```
+```
+lzma -d http://home.apache.org/~mikemccand/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma
+```
+This file is required in the `corpus` directory. If you have many repositories and want to save on space, you can save the corpus to another directory and use symlinks.
+```
+ln -s ~/bench_corpus/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt ./corpus/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt
 ```
 
 The search tasks are from [here](https://github.com/mikemccand/luceneutil/blob/master/tasks/wikimedium.1M.nostopwords.tasks). This repository has a copy, too.
@@ -28,9 +35,9 @@ PhraseQuery (with slop)
 ## Engine details
 ### Common
 * Text analysis: Both engine use a simple whitespace tokenizer.
-* Both indices are force merged down to a single segment
+* Both indices are force merged down to a single segment.
 * A single search thread executes each task TK times, discards the first TK (warmup), and records the minimum time of the remaining 8.
-* The search thread is a simple Rust client, spwaning a sub-process running either Tantivy or Lucene and communicating over a local Unix pipe
+* The search thread is a simple Rust client, spwaning a sub-process running either Tantivy or Lucene and communicating over a local Unix pipe.
 
 ### Tantivy
 * Version: 0.19
@@ -54,7 +61,8 @@ The workload is run against both engines in multiple iterations, including a war
 * `make` is used to manage tasks.
 * You need rust. The recommended way to install it via [rustup](https://www.rust-lang.org/tools/install)
 * JDK 17+. The are plenty of ways to install it.
-* Gardle - 8.1 or up.
+* Gradle - 8.1 or up.
+* Python3.6+.
 
 ## Quick verification
 ```
@@ -62,8 +70,8 @@ make clean
 
 # build the engines, also make indices using the dev corpus
 # the dev corpus is a down-sampled version of the larger corpus
-# this is useful for fast development/iteartion
-make dev-index  
+# this is useful for fast development/iteration
+make dev-index
 
 # run the benchmark
 make bench
@@ -86,6 +94,6 @@ make index bench serve
 ```
 
 ## About the results...
-This repo is still work-in-progress of building the trust of the results. It tries to make an apple-to-apple comparison as much as possible. 
+This repo is still work-in-progress of building the trust of the results. It tries to make an apple-to-apple comparison as much as possible.
 
 It is totally possible that your run of the benchmark turns out to be much different that mine. Make sure you take into account of your hardware environment when interpreting the results.


### PR DESCRIPTION
Replacing `serve` with `serve_local` and adding a `serve` for non local host serving.
The reason I needed `serve` to not include `--bind localhost` is that I am running the benchmarks on an EC2 instance and viewing results on mac laptop.

Also contains:
* Misc readme additions.
* Some typo fixes.

Let me know if any of these changes should be in other files and I can move them.