### PR TITLE
Add tool to merge report.jsons (each json must have unique engine names)

### DIFF
--- a/src/merge_jsons.py
+++ b/src/merge_jsons.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+"""
+This will merge 2 or more results.json files together to present in one "serve" report.
+
+This tool will replace keys in the merge, so you NEED unique names for EACH engines in EACH json.
+e.g. in json1 you could have the engine called "graviton2-tantivy-0.20" and in json2, "graviton3-tantivy-0.20".
+Same for other engines.
+
+Sample usage:
+    python3 src/merge_jsons.py --input_jsons foo.json bar.json more.json --output_json ./results2.json
+
+
+Dependencies:
+    * mergedeep
+
+pip3 install mergedeep to download this.
+"""
+import argparse
+import json
+
+from mergedeep import merge
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-js",
+        "--input_jsons",
+        dest="input_jsons",
+        action="extend",
+        nargs="*",
+        default=[],
+        required=True,
+    )
+
+    parser.add_argument(
+        "-out",
+        "--output_json",
+        dest="output_json",
+        required=True,
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if not args.input_jsons or len(args.input_jsons) < 2 or not args.output_json:
+        raise argparse.ArgumentTypeError("You need to specify input json files and an output json file.")
+
+    merged_json = dict()
+    for input_json in args.input_jsons:
+        with open(input_json, "r") as in_file:
+            current_json = json.load(in_file)
+            merge(merged_json, current_json)
+
+    with open(args.output_json, "w") as out_file:
+        json.dump(merged_json, out_file)

--- a/src/merge_jsons.py
+++ b/src/merge_jsons.py
@@ -1,29 +1,35 @@
 #!/usr/bin/env python3
 
 """
-This will merge 2 or more results.json files together to present in one "serve" report.
+This tool will merge 2 or more results.json files together to present in one "serve" report.
 
-This tool will replace keys in the merge, so you NEED unique names for EACH engines in EACH json.
+The keys will be merged, so you NEED unique names for EACH engines in EACH json.
 e.g. in json1 you could have the engine called "graviton2-tantivy-0.20" and in json2, "graviton3-tantivy-0.20".
-Same for other engines.
-
-Sample usage:
-    python3 src/merge_jsons.py --input_jsons foo.json bar.json more.json --output_json ./results2.json
-
 
 Dependencies:
     * mergedeep
 
-pip3 install mergedeep to download this.
+Sample usage:
+    python3 src/merge_jsons.py --input_jsons foo.json bar.json more.json --output_json ./results2.json
 """
 import argparse
 import json
 
 from mergedeep import merge
 
+# Installing dependencies:
+# pip3 install mergedeep
+
+# sed commands for easy changes to the results.json keys
+# sed -i -e "s/"tantivy-0.20"/"graviton-tantivy-0.20"/g" ./results_graviton.json
+# sed -i -e "s/"lucene-9.7.0"/"graviton-lucene-9.7.0"/g" ./results_graviton.json
+
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
 
     parser.add_argument(
         "-js",

--- a/src/merge_jsons.py
+++ b/src/merge_jsons.py
@@ -20,7 +20,7 @@ from mergedeep import merge
 # Installing dependencies:
 # pip3 install mergedeep
 
-# sed commands for easy changes to the results.json keys
+# sed commands for easy changes to the results.json keys:
 # sed -i -e "s/"tantivy-0.20"/"graviton-tantivy-0.20"/g" ./results_graviton.json
 # sed -i -e "s/"lucene-9.7.0"/"graviton-lucene-9.7.0"/g" ./results_graviton.json
 
@@ -62,4 +62,4 @@ if __name__ == "__main__":
             merge(merged_json, current_json)
 
     with open(args.output_json, "w") as out_file:
-        json.dump(merged_json, out_file)
+        json.dump(merged_json, out_file, indent=2, default=lambda obj: obj.__dict__)


### PR DESCRIPTION
```
This will merge 2 or more results.json files together to present in one "serve" report.

This tool will replace keys in the merge, so you NEED unique names for EACH engines in EACH json.
e.g. in json1 you could have the engine called "graviton2-tantivy-0.20" and in json2, "graviton3-tantivy-0.20".
Same for other engines.

Sample usage:
    python3 src/merge_jsons.py --input_jsons foo.json bar.json more.json --output_json ./results2.json


Dependencies:
    * mergedeep

pip3 install mergedeep to download this.

```
I was manually merging jsons when doing some testing recently. This tool may be useful to automate that a bit.

Unfortunately, we need unique engine names in each report to use this tool.

Some solutions for this:
* Add an optional `ALIAS` variable to the Makefile to have e.g. a graviton2 report have `graviton2` alias and the engine in the results.json would pre-appended with the alias.
* Not use `mergedeep` and merge ourselves while pre-appending an index (or alias param?) to each engine... This may be a less simple solution.
* Give users sample `sed` commands.

Here is a sample output of 3 merged jsons.
![image](https://github.com/Tony-X/search-benchmark-game/assets/32519034/f8e7505b-6e0b-43da-87d5-cb1b2363e545)
