### PR TITLE
Allow client to work with JFR 

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -47,7 +47,7 @@ class SearchClient:
         if 1 <= len(tup) <= 2 and isinstance(tup[0], str) and tup[0][0] == '[':
             elapsed_secs, result, jfr_debug = tup[0].strip('][').split('][')
             # in form of 0.357s, removing trailing 's'
-            elapsed_micros = elapsed_secs[:-1] * 1000000
+            elapsed_micros = float(elapsed_secs[:-1]) * 1000000
             return elapsed_micros, None
 
         if len(tup) != 2:

--- a/src/client.py
+++ b/src/client.py
@@ -1,10 +1,8 @@
 import subprocess
 import os
 from os import path
-import time
 import json
 import random
-from collections import defaultdict
 
 
 COMMANDS = os.environ['COMMANDS'].split(' ')

--- a/src/client.py
+++ b/src/client.py
@@ -44,8 +44,17 @@ class SearchClient:
         recv = self.run_command(query_line)
         # print('  recv: ' + recv)
         tup = recv.split(' ', 1)
+
+        # Ignore responses from jfr diagnostics, sometimes the length of jfr response tuple is 1
+        if 1 <= len(tup) <= 2 and isinstance(tup[0], str) and tup[0][0] == '[':
+            elapsed_secs, result, jfr_debug = tup[0].strip('][').split('][')
+            # in form of 0.357s, removing trailing 's'
+            elapsed_micros = elapsed_secs[:-1] * 1000000
+            return elapsed_micros, None
+
         if len(tup) != 2:
             raise RuntimeError(f'malformed response "{recv}"\n{self.process.stderr.read().decode("utf-8")}')
+
         elapsed_nanos, result = tup
         elapsed_micros = int(elapsed_nanos) // 1000
         if result == "UNSUPPORTED":


### PR DESCRIPTION
I was playing around with enabling Java Flight Recorder to look at the graviton issue, https://github.com/Tony-X/search-benchmark-game/issues/36 . While comparing the graviton3 vs graviton 2 jfr didn't bring up anything too interesting, I'll push this so there is less setup required next time we look at jfr.

![image](https://github.com/Tony-X/search-benchmark-game/assets/32519034/b4d67697-856b-4596-b588-b177caa6b236)

Changes to Lucene Makefile in testing:
```
serve:
        @java -Xmx$(HEAP) -Xms$(HEAP) -XX:+UseParallelGC -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+FlightRecorder -XX:StartFlightRecording=dumponexit=true,filename=grav3.jfr,settings=profile -cp build/libs/search-index-benchmark-game-lucene-1.0-SNAPSHOT-all.jar DoQuery idx
```
