### PR TITLE
Adding testing for TOP N = 100

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export
 
 # What to bench?
 # COMMANDS ?= TOP_10
-COMMANDS ?= TOP_10_COUNT COUNT
+COMMANDS ?= TOP_10_COUNT TOP_100_COUNT COUNT
 ENGINES ?= tantivy-0.20 lucene-9.7.0
 QUERY_FILE ?= queries/basic_queries.jsonl
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export
 
 # What to bench?
 # COMMANDS ?= TOP_10
-COMMANDS ?= TOP_10_COUNT TOP_100_COUNT COUNT
+COMMANDS ?= TOP_10_COUNT COUNT TOP_100
 ENGINES ?= tantivy-0.20 lucene-9.7.0
 QUERY_FILE ?= queries/basic_queries.jsonl
 

--- a/engines/lucene-9.7.0/src/main/java/DoQuery.java
+++ b/engines/lucene-9.7.0/src/main/java/DoQuery.java
@@ -44,14 +44,25 @@ public class DoQuery {
                             break;
                         case "TOP_10":
                         {
-                            final TopDocs topDocs = searcher.search(query, 10);
-                            int count = (int) topDocs.totalHits.value;
+                            // Collector enabled manually to enable dynamic pruning immediately.
+                            final TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(10, 10);
+                            searcher.search(query, topScoreDocCollector);
+                            int count = topScoreDocCollector.getTotalHits();
+                            result = Integer.toString(count);
+                        }
+                            break;
+                        case "TOP_100":
+                        {
+                            // Collector enabled manually to enable dynamic pruning immediately.
+                            final TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(100, 100);
+                            searcher.search(query, topScoreDocCollector);
+                            int count = topScoreDocCollector.getTotalHits();
                             result = Integer.toString(count);
                         }
                             break;
                         case "TOP_10_COUNT":
                         {
-                            // NOTE: this disables BMW (by passing 2nd argument Integer.MAX_VALUE
+                            // NOTE: this disables BMW (by passing 2nd argument Integer.MAX_VALUE)
                             final TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(10, Integer.MAX_VALUE);
                             searcher.search(query, topScoreDocCollector);
                             int count = topScoreDocCollector.getTotalHits();
@@ -62,7 +73,7 @@ public class DoQuery {
                         {
                             assert fields.length == 3;
                             int n = Integer.parseInt(fields[2]);
-                            // TODO: why not just the IS.search method?
+                            // Collector enabled manually to enable dynamic pruning immediately.
                             final TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(n, n);
                             searcher.search(query, topScoreDocCollector);
                             StringBuilder sb = new StringBuilder();

--- a/engines/tantivy-0.20/src/bin/do_query.rs
+++ b/engines/tantivy-0.20/src/bin/do_query.rs
@@ -119,12 +119,10 @@ fn main_inner(index_dir: &Path) -> tantivy::Result<()> {
         let result: String = match command {
             "COUNT" => query.count(&searcher)?.to_string(),
             "TOP_10" => {
-                let _top_docs = searcher.search(&query, &TopDocs::with_limit(10))?;
-                _top_docs.len().to_string()
+                top_n_total_hits(10, &searcher, &query)
             }
             "TOP_100" => {
-                let _top_docs = searcher.search(&query, &TopDocs::with_limit(100))?;
-                _top_docs.len().to_string()
+                top_n_total_hits(100, &searcher, &query)
             }
             "TOP_10_COUNT" => {
                 let (_top_docs, count) =
@@ -169,4 +167,9 @@ fn main_inner(index_dir: &Path) -> tantivy::Result<()> {
     }
 
     Ok(())
+}
+
+fn top_n_total_hits(limit: usize, searcher: &tantivy::Searcher, query: &dyn tantivy::query::Query) -> String {
+    let _top_docs = searcher.search(query, &TopDocs::with_limit(limit)).unwrap();
+    _top_docs.len().to_string()
 }

--- a/engines/tantivy-0.20/src/bin/do_query.rs
+++ b/engines/tantivy-0.20/src/bin/do_query.rs
@@ -122,6 +122,10 @@ fn main_inner(index_dir: &Path) -> tantivy::Result<()> {
                 let _top_docs = searcher.search(&query, &TopDocs::with_limit(10))?;
                 _top_docs.len().to_string()
             }
+            "TOP_100" => {
+                let _top_docs = searcher.search(&query, &TopDocs::with_limit(100))?;
+                _top_docs.len().to_string()
+            }
             "TOP_10_COUNT" => {
                 let (_top_docs, count) =
                     searcher.search(&query, &(TopDocs::with_limit(10), Count))?;


### PR DESCRIPTION
While I am making changes to the DoQuery class, I'm also enabling dynamic pruning immediately.

![image](https://github.com/Tony-X/search-benchmark-game/assets/32519034/c0341999-bb97-45a9-9b01-e5ac7ee940c6)

Closes https://github.com/Tony-X/search-benchmark-game/issues/2, https://github.com/Tony-X/search-benchmark-game/issues/41.

---


TODO: 
* [Done] upload new `web/build/results.json`, pending re-run of benchmark.
* [Discussed below] Is the Lucene DoQuery respecting the TotalHitsThreshold? See picture above, why is the doc count not 100 like Tantivy?