### PR TITLE
Allowing use of Jdk19+ by disabling enableMemorySegments

### DIFF
--- a/engines/lucene-9.7.0/Makefile
+++ b/engines/lucene-9.7.0/Makefile
@@ -14,7 +14,7 @@ clean-index:
 compile: build
 
 serve:
-	@java -Xmx$(HEAP) -Xms$(HEAP) -XX:+UseParallelGC -cp build/libs/search-index-benchmark-game-lucene-1.0-SNAPSHOT-all.jar DoQuery idx
+	@java -Xmx$(HEAP) -Xms$(HEAP) -XX:+UseParallelGC -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false -cp build/libs/search-index-benchmark-game-lucene-1.0-SNAPSHOT-all.jar DoQuery idx
 
 index: idx
 
@@ -24,4 +24,4 @@ build: src/main/java/*.java
 
 idx: build
 	@echo "--- Indexing $(NAME) with %$(INDEX_DELETE_PCT) deletes ---"
-	java -server -cp build/libs/search-index-benchmark-game-lucene-1.0-SNAPSHOT-all.jar BuildIndex idx $(INDEX_DELETE_PCT) < $(CORPUS)
+	java -server -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false -cp build/libs/search-index-benchmark-game-lucene-1.0-SNAPSHOT-all.jar BuildIndex idx $(INDEX_DELETE_PCT) < $(CORPUS)

--- a/src/merge_jsons.py
+++ b/src/merge_jsons.py
@@ -18,11 +18,11 @@ import json
 try:
     from mergedeep import merge
 except ImportError as e:
-    print("Failed importing mergedeep, you may be missing this dependency.\nRun: 'pip3 install mergedeep' to install.\n")
+    print("Failed importing mergedeep, you may be missing this dependency.\nRun: 'python3 -m pip install mergedeep --user' to install.\n")
     raise e
 
 # Installing dependencies:
-# pip3 install mergedeep
+# python3 -m pip install mergedeep --user
 
 # sed commands for easy changes to the results.json keys:
 # sed -i -e "s/"tantivy-0.20"/"graviton-tantivy-0.20"/g" ./results_graviton.json

--- a/src/merge_jsons.py
+++ b/src/merge_jsons.py
@@ -15,7 +15,11 @@ Sample usage:
 import argparse
 import json
 
-from mergedeep import merge
+try:
+    from mergedeep import merge
+except ImportError as e:
+    print("Failed importing mergedeep, you may be missing this dependency.\nRun: 'pip3 install mergedeep' to install.\n")
+    raise e
 
 # Installing dependencies:
 # pip3 install mergedeep


### PR DESCRIPTION
Also fixing import error message in merge_jsons.py

Results from running with JDK20 enabled on `m5.12xlarge` machine. Attaching same results.json
[results 2.json.zip](https://github.com/Tony-X/search-benchmark-game/files/12659962/results.2.json.zip)


Closes #47.